### PR TITLE
Fixed syntax error in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,6 +83,7 @@ warn_amd_chip_compatibility() {
             log "  Installation will continue so the DKMS module is ready for future use."
             log "------------------------------------------------------------"
         fi
+    fi
 }
 
 check_dependencies() {


### PR DESCRIPTION
In a part of the script not relevant to me, but high priority because it prevents the script from being run by all users.