### PR TITLE
CI: multi-distro release packages (deb/rpm/arch/alpine/gentoo/unRAID)

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,89 @@
+name: Build Distribution Packages
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version (defaults to repo VERSION/ref name)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.distro }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: deb
+            image: debian:bookworm-slim
+          - distro: rpm
+            image: fedora:latest
+          - distro: arch
+            image: archlinux:base-devel
+          - distro: alpine
+            image: alpine:3.21
+          - distro: generic
+            image: '' # plain runner, tarballs only
+    container: ${{ matrix.image != '' && matrix.image || null }}
+    env:
+      PKGVER: ${{ github.event.inputs.version || github.ref_name }}
+    steps:
+      - name: Normalize version (strip leading v)
+        run: echo "PKGVER=${PKGVER#v}" >> "$GITHUB_ENV"
+
+      - name: Fetch repository source
+        run: |
+          if command -v apt-get >/dev/null 2>&1; then
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq >/dev/null && apt-get install -y -qq --no-install-recommends git ca-certificates curl >/dev/null
+          elif command -v dnf >/dev/null 2>&1; then
+            dnf -y install --quiet git ca-certificates curl >/dev/null 2>&1
+          elif command -v pacman >/dev/null 2>&1; then
+            pacman -Sy --noconfirm --quiet git ca-certificates curl >/dev/null 2>&1
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --quiet git ca-certificates curl >/dev/null
+          fi
+          curl -fsSL "https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz" -o /tmp/repo.tar.gz
+          mkdir -p /tmp/repo && tar -xzf /tmp/repo.tar.gz -C /tmp/repo --strip-components=1
+          echo "SRC_DIR=/tmp/repo" >> "$GITHUB_ENV"
+
+      - name: Build package (${{ matrix.distro }})
+        run: |
+          mkdir -p /out
+          if [ "${{ matrix.distro }}" = "generic" ]; then
+            bash "$SRC_DIR/packaging/build-gentoo.sh"
+            bash "$SRC_DIR/packaging/build-unraid.sh"
+          else
+            bash "$SRC_DIR/packaging/build-${{ matrix.distro }}.sh"
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ matrix.distro }}
+          path: /out/*
+          if-no-files-found: error
+
+  release:
+    name: Attach packages to release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Attach to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*

--- a/packaging/build-alpine.sh
+++ b/packaging/build-alpine.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Build an Alpine Linux APK package for the DKMS driver source.
+# Runs inside alpine:3.21. Env: PKGVER
+set -eu
+: "${PKGVER:?}"
+
+apk add --quiet bash >/dev/null 2>&1 || true
+# enable community repo (akms lives there)
+echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories
+apk update --quiet >/dev/null
+apk add --quiet akms >/dev/null 2>&1 || true
+
+apk add --quiet git alpine-sdk sudo >/dev/null
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$SCRIPT_DIR/prepare-payload.sh"
+
+adduser -D builduser 2>/dev/null || true
+addgroup builduser abuild 2>/dev/null || true
+mkdir -p "${OUT_DIR:-/out}" && chmod 777 "${OUT_DIR:-/out}"
+chmod -R a+rX /tmp/payload
+
+mkdir -p /tmp/aports/ugreen-it87-dkms
+cat > /tmp/aports/ugreen-it87-dkms/APKBUILD <<EOF
+# Maintainer: IT-Kuny <it-kuny@users.noreply.github.com>
+pkgname=ugreen-it87-dkms
+pkgver=$PKGVER
+pkgrel=0
+pkgdesc="UGREEN DXP NAS system fan kernel driver (it87) — DKMS source"
+url="https://github.com/IT-Kuny/UGREEN-DXP-FAN-NAS-Driver"
+arch="noarch"
+license="GPL-2.0-or-later"
+depends="akms"
+source="\$pkgname-\$pkgver.tar.gz"
+options="!check !fakeroot"
+sha512sums="SKIP"
+
+package() {
+    mkdir -p "\$pkgdir"/usr/src/it87-\$pkgver
+    cp -r /tmp/payload/it87-\$pkgver/* "\$pkgdir"/usr/src/it87-\$pkgver/
+}
+EOF
+
+tar -C /tmp/payload -czf /tmp/aports/ugreen-it87-dkms/ugreen-it87-dkms-$PKGVER.tar.gz it87-$PKGVER
+chown -R builduser /tmp/aports /tmp/payload "${OUT_DIR:-/out}"
+
+# Local signing key (untrusted, needed for abuild to produce an apk)
+su builduser -c 'abuild-keygen -a -n -i >/dev/null 2>&1 || abuild-keygen -a -n >/dev/null'
+
+su builduser -c 'cd /tmp/aports/ugreen-it87-dkms && abuild checksum >/dev/null && abuild -r'
+
+cp /home/builduser/packages/ugreen-it87-dkms/noarch/*.apk ${OUT_DIR:-/out}/ || \
+    cp /home/builduser/packages/*/noarch/*.apk ${OUT_DIR:-/out}/ || true
+
+echo "Built apk:"
+ls -la ${OUT_DIR:-/out}/

--- a/packaging/build-arch.sh
+++ b/packaging/build-arch.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Build an Arch Linux DKMS package (.pkg.tar.zst). Covers Arch and Arch-based
+# distros like Omarchy. Runs inside archlinux:base-devel. Env: PKGVER
+set -euo pipefail
+: "${PKGVER:?}"
+ARCHVER="${PKGVER//-/}"
+
+pacman -Sy --noconfirm --quiet git >/dev/null 2>&1
+useradd -m builduser 2>/dev/null || true
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+source "$SCRIPT_DIR/common.sh"
+chmod -R a+rX /tmp/payload
+mkdir -p "${OUT_DIR:-/out}" && chmod 777 /out
+
+cat > /tmp/PKGBUILD <<EOF
+pkgname=ugreen-it87-dkms
+pkgver=${PKGVER}
+pkgrel=1
+pkgdesc="UGREEN DXP NAS system fan kernel driver (it87) — DKMS source"
+arch=('any')
+url="https://github.com/IT-Kuny/UGREEN-DXP-FAN-NAS-Driver"
+license=('GPL2')
+depends=('dkms')
+source=("\$pkgname-\$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+package() {
+    install -dm755 "\$pkgdir/usr/src/it87-\$pkgver"
+    cp -r /tmp/payload/it87-\$pkgver/* "\$pkgdir/usr/src/it87-\$pkgver/"
+}
+EOF
+
+# Tarball name matching source= entry
+tar -C /tmp/payload -czf /tmp/ugreen-it87-dkms-${ARCHVER}.tar.gz it87-${PKGVER}
+
+chown -R builduser /tmp/PKGBUILD /tmp/ugreen-it87-dkms-${PKGVER}.tar.gz /tmp/payload /out
+
+sudo -u builduser bash -c '
+set -e
+mkdir -p /tmp/work && cd /tmp/work
+cp /tmp/PKGBUILD /tmp/ugreen-it87-dkms-'"${PKGVER}"'.tar.gz .
+makepkg -f --noconfirm --skippgpcheck --nodeps
+cp ugreen-it87-dkms-*.pkg.tar.zst ${OUT_DIR:-/out}/
+'
+
+echo "Built arch package:"
+ls -la ${OUT_DIR:-/out}/

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Build a Debian/Ubuntu DKMS source package (.deb).
+# Runs inside debian:bookworm-slim. Env: PKGVER
+set -euo pipefail
+: "${PKGVER:?}"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq && apt-get install -y -qq --no-install-recommends git >/dev/null
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+source "$SCRIPT_DIR/common.sh"
+
+VENDOR="IT-Kuny"
+MAINT="IT-Kuny <https://github.com/IT-Kuny>"
+PKG="ugreen-it87-dkms"
+DEST="/tmp/$PKG\_$PKGVER\_all"
+MODULE=it87
+
+rm -rf "$DEST"
+mkdir -p "$DEST/DEBIAN" "$DEST/usr/src" "$DEST/usr/share/doc/$PKG"
+
+cp -r "$PAYLOAD_DIR/$MODULE-$PKGVER" "$DEST/usr/src/"
+cp "$PAYLOAD_DIR/$MODULE-$PKGVER/LICENSE" "$DEST/usr/share/doc/$PKG/copyright"
+
+cat > "$DEST/DEBIAN/control" <<EOF
+Package: $PKG
+Version: $PKGVER
+Section: kernel
+Priority: optional
+Architecture: all
+Depends: dkms
+Recommends: linux-headers
+Maintainer: $MAINT
+Homepage: https://github.com/IT-Kuny/UGREEN-DXP-FAN-NAS-Driver
+Description: UGREEN DXP NAS system fan kernel driver (it87) — DKMS source
+ Out-of-tree it87 hwmon driver with UGREEN NAS OEM chip support
+ (DXP2800, DXP4800, DXP8800, iDX6011, DXP2800 GT and others).
+ The module is compiled locally against the running kernel via DKMS.
+EOF
+
+cat > "$DEST/DEBIAN/postinst" <<EOF
+#!/bin/bash
+set -e
+if command -v dkms >/dev/null 2>&1; then
+    dkms add -m $MODULE/$PKGVER || true
+    dkms build -m $MODULE/$PKGVER && dkms install --force -m $MODULE/$PKGVER || \
+        echo "[postinst] DKMS build/install deferred — install matching kernel headers and run: dkms autoinstall"
+    modprobe $MODULE 2>/dev/null || true
+fi
+EOF
+
+cat > "$DEST/DEBIAN/prerm" <<EOF
+#!/bin/bash
+set -e
+dkms remove -m $MODULE/$PKGVER --all || true
+EOF
+
+chmod 755 "$DEST/DEBIAN/postinst" "$DEST/DEBIAN/prerm"
+
+mkdir -p "${OUT_DIR:-/out}"
+OUT="${OUT_DIR:-/out}/${PKG}_${PKGVER}_all.deb"
+dpkg-deb --build --root-owner-group "$DEST" "$OUT"
+echo "Built $OUT"

--- a/packaging/build-gentoo.sh
+++ b/packaging/build-gentoo.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Assemble the Gentoo ebuild overlay tarball + generic DKMS source tarball.
+# Runs on plain ubuntu runner (no container needed). Env: PKGVER
+set -euo pipefail
+: "${PKGVER:?}"
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+source "$SCRIPT_DIR/common.sh"
+
+mkdir -p "$OUT_DIR"
+
+# Generic DKMS source tarball (usable on any distro via `dkms add`):
+tar -C /tmp/payload -czf "$OUT_DIR/it87-$PKGVER-dkms-source.tar.gz" it87-$PKGVER
+
+# Gentoo overlay
+OVERLAY=/tmp/ugreen-it87-overlay
+rm -rf "$OVERLAY"
+mkdir -p "$OVERLAY"/{metadata,profiles,sys-kernel/ugreen-it87-dkms}
+
+echo 'masters = gentoo' > "$OVERLAY/metadata/layout.conf"
+echo 'ugreen-it87' > "$OVERLAY/profiles/repo_name"
+
+cat > "$OVERLAY/sys-kernel/ugreen-it87-dkms/metadata.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>noreply@github.com</email>
+    <name>IT-Kuny</name>
+  </maintainer>
+  <longdescription>UGREEN DXP NAS system fan kernel driver (it87) with UGREEN
+  OEM chip support, installed as DKMS source.</longdescription>
+</pkgmetadata>
+EOF
+
+sed "s/VERSION/$PKGVER/" "$SCRIPT_DIR/gentoo/ugreen-it87-dkms-VERSION.ebuild" \
+    > "$OVERLAY/sys-kernel/ugreen-it87-dkms/ugreen-it87-dkms-$PKGVER.ebuild"
+
+tar -C /tmp -czf "$OUT_DIR/ugreen-it87-gentoo-overlay-$PKGVER.tar.gz" ugreen-it87-overlay
+
+echo "Built generic source + gentoo overlay tarballs"
+ls -la $OUT_DIR/

--- a/packaging/build-rpm.sh
+++ b/packaging/build-rpm.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Build a Fedora/RHEL DKMS source package (.rpm, noarch).
+# Runs inside fedora:latest. Env: PKGVER
+set -euo pipefail
+: "${PKGVER:?}"
+
+dnf -y install --quiet rpm-build rpmdevtools git >/dev/null 2>&1
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+source "$SCRIPT_DIR/common.sh"
+
+MODULE=it87
+PKG=ugreen-it87-dkms
+
+rpmdev-setuptree
+SPEC=~/rpmbuild/SPECS/$PKG.spec
+mkdir -p ~/rpmbuild/SPECS
+
+# Vendor the source payload as tarball for the build
+TARBALL=~/rpmbuild/SOURCES/$MODULE-$PKGVER.tar.gz
+tar -C "$PAYLOAD_DIR" -czf "$TARBALL" $MODULE-$PKGVER
+
+cat > "$SPEC" <<EOF
+Name:    $PKG
+Version: $PKGVER
+Release: 1%{?dist}
+Summary: UGREEN DXP NAS system fan kernel driver (it87) — DKMS source
+License: GPL-2.0-or-later
+URL:     https://github.com/IT-Kuny/UGREEN-DXP-FAN-NAS-Driver
+Source0: $MODULE-%{version}.tar.gz
+BuildArch: noarch
+Requires: dkms
+Recommends: kernel-devel
+
+%description
+Out-of-tree it87 hwmon driver with UGREEN NAS OEM chip support
+(DXP2800, DXP4800, DXP8800, iDX6011, DXP2800 GT and others).
+The module is compiled locally against the running kernel via DKMS.
+
+%prep
+%setup -q -n $MODULE-%{version}
+
+%build
+# nothing to build — DKMS compiles at install time
+
+%install
+mkdir -p %{buildroot}/usr/src/$MODULE-%{version}
+cp -r dkms.conf VERSION Makefile it87.c LICENSE %{buildroot}/usr/src/$MODULE-%{version}/
+
+%post
+if command -v dkms >/dev/null 2>&1; then
+    dkms add -m $MODULE/%{version} || :
+    dkms build -m $MODULE/%{version} && dkms install --force -m $MODULE/%{version} || \
+        echo "[post] DKMS build deferred — install kernel-devel/kernel headers and run: dkms autoinstall"
+    modprobe $MODULE 2>/dev/null || :
+fi
+
+%preun
+dkms remove -m $MODULE/%{version} --all || :
+
+%files
+/usr/src/$MODULE-%{version}/
+%license LICENSE
+
+%changelog
+* $(date '+%a %b %d %Y') IT-Kuny - $PKGVER-1
+- Automated build for release $PKGVER
+EOF
+
+mkdir -p "${OUT_DIR:-/out}"
+rpmbuild -bb --quiet "$SPEC"
+cp ~/rpmbuild/RPMS/noarch/$PKG-$PKGVER-1.*.noarch.rpm "${OUT_DIR:-/out}/${PKG}-${PKGVER}-1.noarch.rpm"
+echo "Built rpm for $PKGVER"
+ls -la ${OUT_DIR:-/out}/

--- a/packaging/build-unraid.sh
+++ b/packaging/build-unraid.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Generate the unRAID plugin file (.plg).
+# unRAID has no package manager for kernel modules — plugins build on-device
+# against the running unRAID kernel. Env: PKGVER, PLG_BASE_URL
+set -euo pipefail
+: "${PKGVER:?}"
+
+: "${PLG_BASE_URL:=https://github.com/IT-Kuny/UGREEN-DXP-FAN-NAS-Driver/releases/download/v${PKGVER}}"
+OUT_DIR="${OUT_DIR:-/out}"
+mkdir -p "$OUT_DIR"
+
+cat > "$OUT_DIR/ugreen-it87.plg" <<EOF
+<?xml version="1.0"?>
+<PLUGIN name="ugreen-it87" author="IT-Kuny" version="$PKGVER"
+  pluginURL="" min="6.12.0">
+<CONFLICT />
+<SUPPORT>https://github.com/IT-Kuny/UGREEN-DXP-FAN-NAS-Driver/issues</SUPPORT>
+<CHANGELOG>
+<![CDATA[
+v$PKGVER — automated release build
+]]>
+</CHANGELOG>
+<DESCRIPTION>
+<![CDATA[
+UGREEN DXP NAS system fan driver (it87) for unRAID.
+Downloads the driver source, builds the out-of-tree it87 hwmon module
+against the running unRAID kernel and loads it.
+Supports DXP2800, DXP4800, DXP8800, iDX6011 and DXP2800 GT.
+Fan control is handled by the UGREEN-Fan-Control daemon or fancontrol.
+]]>
+</DESCRIPTION>
+<FILE Name="/boot/config/plugins/ugreen-it87/source.txz" URL="$PLG_BASE_URL/it87-$PKGVER-dkms-source.tar.gz" Min="6.12.0">
+<HELP>Driver source tarball</HELP>
+</FILE>
+<FILE Run="/bin/bash">
+<INLINE>
+<![CDATA[
+set -e
+SRC="/boot/config/plugins/ugreen-it87/source"
+rm -rf "\$SRC" && mkdir -p "\$SRC"
+VER="\$(tar -xzOf /boot/config/plugins/ugreen-it87/source.txz --wildcards '*/VERSION' | head -1)"
+tar -xzf /boot/config/plugins/ugreen-it87/source.txz -C "\$SRC" --strip-components=1
+echo "[ugreen-it87] Building v\$VER for kernel \$(uname -r) ..."
+cd "\$SRC"
+make clean >/dev/null 2>&1 || true
+make -j"\$(nproc)"
+make install
+depmod -a
+modprobe it87 ignore_resource_conflict=1 || true
+echo "[ugreen-it87] Loaded. Verify with: sensors | grep -A3 it87"
+]]>
+</INLINE>
+</FILE>
+</PLUGIN>
+EOF
+
+echo "Built $OUT_DIR/ugreen-it87.plg"
+ls -la "$OUT_DIR/"

--- a/packaging/common.sh
+++ b/packaging/common.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Shared env for per-distro build scripts (sourced).
+export PAYLOAD_DIR=${PAYLOAD_DIR:-/tmp/payload}
+export OUT_DIR=${OUT_DIR:-/out}
+export MODULE=it87
+export PKGNAME=ugreen-it87-dkms
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)
+"$SCRIPT_DIR/prepare-payload.sh"

--- a/packaging/gentoo/ugreen-it87-dkms-VERSION.ebuild
+++ b/packaging/gentoo/ugreen-it87-dkms-VERSION.ebuild
@@ -1,0 +1,34 @@
+# Copyright 2026 IT-Kuny
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="UGREEN DXP NAS system fan kernel driver (it87) — DKMS source"
+HOMEPAGE="https://github.com/IT-Kuny/UGREEN-DXP-FAN-NAS-Driver"
+SRC_URI="https://github.com/IT-Kuny/UGREEN-DXP-FAN-NAS-Driver/releases/download/v${PV}/it87-${PV}.tar.gz"
+
+LICENSE="GPL-2.0-or-later"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="sys-kernel/dkms"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/it87-${PV}"
+
+src_install() {
+    insinto "/usr/src/it87-${PV}"
+    doins dkms.conf VERSION Makefile it87.c LICENSE
+}
+
+pkg_postinst() {
+    dkms add -m it87/${PV} || true
+    dkms build -m it87/${PV} && dkms install --force -m it87/${PV} || \
+        elog "DKMS build deferred — install sys-kernel/linux-headers for your kernel and run: dkms autoinstall"
+    modprobe it87 2>/dev/null || true
+}
+
+pkg_prerm() {
+    dkms remove -m it87/${PV} --all || true
+}

--- a/packaging/prepare-payload.sh
+++ b/packaging/prepare-payload.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Prepare the DKMS source payload shared by all package builds.
+# Env: PKGVER (package version), SRC_DIR (repo checkout dir), OUT payload dir.
+set -euo pipefail
+
+: "${PKGVER:?PKGVER must be set}"
+SRC_DIR="${SRC_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PAYLOAD_DIR="${PAYLOAD_DIR:-/tmp/payload}"
+MODULE=it87
+
+rm -rf "$PAYLOAD_DIR"
+mkdir -p "$PAYLOAD_DIR/$MODULE-$PKGVER"
+
+# dkms.conf: fill in the version (same substitution `make dkms` does)
+sed -e "/^PACKAGE_VERSION=/ s|.*|PACKAGE_VERSION=\"$PKGVER\"|" \
+    "$SRC_DIR/it87/dkms.conf" > "$PAYLOAD_DIR/$MODULE-$PKGVER/dkms.conf"
+
+echo "$PKGVER" > "$PAYLOAD_DIR/$MODULE-$PKGVER/VERSION"
+
+cp "$SRC_DIR/it87/it87.c" \
+   "$SRC_DIR/it87/Makefile" \
+   "$SRC_DIR/LICENSE" \
+   "$PAYLOAD_DIR/$MODULE-$PKGVER/"
+
+# The Makefile must NOT try to git-describe; freeze the version via VERSION file
+# (Makefile already prefers an existing VERSION file).
+
+echo "Payload prepared at $PAYLOAD_DIR/$MODULE-$PKGVER (version $PKGVER)"


### PR DESCRIPTION
## What

Automated distribution packaging for the it87 driver, attached to GitHub releases on every `v*` tag:

| Artifact | Distro(s) | Build | Local test |
|---|---|---|---|
| `ugreen-it87-dkms_*_all.deb` | Debian, Ubuntu, Proxmox VE | dpkg-deb | ✅ |
| `ugreen-it87-dkms-*.noarch.rpm` | Fedora, RHEL | rpmbuild | ✅ |
| `*.pkg.tar.zst` | Arch, Omarchy | makepkg (DKMS) | ✅ |
| `*.apk` | Alpine | abuild (akms) | ⏳ CI (local faked spins in my docker env — host quirk) |
| `ugreen-it87-gentoo-overlay-*.tar.gz` | Gentoo | ebuild overlay | ✅ |
| `ugreen-it87.plg` | unRAID | on-device build plugin | ✅ XML valid |
| `it87-*-dkms-source.tar.gz` | any | generic DKMS source | ✅ |

## Notes

- All packages are **DKMS source packages** — the module compiles on the user's machine against their running kernel (postinst runs `dkms add/build/install`; falls back to `dkms autoinstall` hint when headers are missing).
- unRAID has no package system → `.plg` plugin downloads the source tarball and builds on-device, per the FAQ's TrueNAS-style approach.
- Omarchy is Arch-based → covered by the Arch package.
- Alpine: no dkms → depends on `akms` (Alpine's DKMS equivalent).

## Verification

- All build scripts tested in real distro containers locally (except alpine, deferred to CI due to host fakeroot issue)
- `bash -n` on all scripts, YAML linted, .plg XML-validated